### PR TITLE
root api now 404s on a non resource

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -18,7 +18,9 @@
 """
 
 import json
-from werkzeug.wrappers import Response
+from werkzeug.exceptions import HTTPException
+from werkzeug.routing import Map, Rule
+from werkzeug.wrappers import Request, Response
 from werkzeug.wsgi import DispatcherMiddleware
 
 # The config imports should come before other package modules so other moudles can import it
@@ -27,7 +29,6 @@ from api import middleware
 from api import data
 from api import repo
 
-
 dispatch_appmap = {
     '/courses': data.Resource(provider_class=data.Course),
     '/subjects': data.Resource(provider_class=data.Subject),
@@ -35,12 +36,39 @@ dispatch_appmap = {
 }
 
 
-def root_app(environ, start_response):
-    resources = {"resources": list(dispatch_appmap.keys())}
-    response = Response(json.dumps(resources), mimetype='application/json')
-    return response(environ, start_response)
+class RootApp(object):
+    """Root app for the api"""
+    def __init__(self):
+        self.url_map = Map([Rule('/', endpoint=self.root_handler)])
 
-app = DispatcherMiddleware(root_app, dispatch_appmap)
+    def root_handler(self, request):
+        if request.method == 'GET':
+            resources = {"resources": list(dispatch_appmap.keys())}
+            return self.render_json(resources)
+        else:
+            raise NotImplemented()
+
+    def render_json(self, data):
+        return Response(json.dumps(data), mimetype='application/json')
+
+    def dispatch_request(self, request):
+        adapter = self.url_map.bind_to_environ(request.environ)
+        try:
+            endpoint, values = adapter.match()
+            return (endpoint)(request, **values)
+        except HTTPException as e:
+            return e
+
+    def wsgi_app(self, environ, start_response):
+        request = Request(environ)
+        response = self.dispatch_request(request)
+        return response(environ, start_response)
+
+    def __call__(self, environ, start_response):
+        return self.wsgi_app(environ, start_response)
+
+app = RootApp()
+app = DispatcherMiddleware(app, dispatch_appmap)
 app = middleware.FieldLimiter(app)
 #app = middleware.DataTransformer(app)
 app = middleware.PrettyJSON(app)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -16,7 +16,7 @@ import tempfile
 from unittest import TestCase
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
-from werkzeug.exceptions import NotAcceptable, BadRequest
+from werkzeug.exceptions import NotAcceptable, BadRequest, NotFound
 
 import api
 from api.config import (
@@ -208,3 +208,18 @@ class TestFieldLimiter(TestCase):
         c = Client(wrapped, BaseResponse)
         resp = c.get('/?field=message')
         self.assertEqual(json_resp(resp), [{'message': test_data['message']}] * 2)
+
+
+class TestRootApp(TestCase):
+
+    def setUp(self):
+        self.app = api.RootApp()
+        self.client = Client(self.app, BaseResponse)
+
+    def test_status_ok(self):
+        response = self.client.get('/', headers=[('Accept', 'application/json')])
+        self.assertEqual(response.status_code, 200)
+
+    def test_status_not_found(self):
+        response = self.client.get('/notaresource')
+        self.assertEqual(response.status_code, 404)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -213,7 +213,7 @@ class TestFieldLimiter(TestCase):
 class TestRootApp(TestCase):
 
     def setUp(self):
-        self.app = api.RootApp()
+        self.app = api.root_app
         self.client = Client(self.app, BaseResponse)
 
     def test_status_ok(self):
@@ -221,5 +221,5 @@ class TestRootApp(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_status_not_found(self):
-        response = self.client.get('/notaresource')
-        self.assertEqual(response.status_code, 404)
+        with self.assertRaises(NotFound):
+            response = self.client.get('/notaresource')


### PR DESCRIPTION
The root api was not strict enough before and would accept anything like `/asdf` and just return the response for `/`
